### PR TITLE
USERを数値UIDで指定してrunAsNonRootを検証可能にする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN apt-get update \
 COPY ./package.json ./package.json
 RUN node -e "console.log(JSON.parse(require('node:fs').readFileSync('./package.json')).packageManager)" | xargs npm install -g
 
-USER misskey
+USER ${UID}
 WORKDIR /misskey
 
 COPY --chown=misskey:misskey --from=target-builder /misskey/node_modules ./node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.7.0-na2na-v1",
+	"version": "2026.7.0-na2na-v2",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## 目的

Atlas の Kyverno ポリシー `disallow-privilege-escalation` / `require-run-as-non-root` を満たすため、helm chart 側で `securityContext.runAsNonRoot: true` を宣言できるようにする。

## 問題

現状 `USER misskey` と名前で指定しているため、image config の `User` が `"misskey"` になる。この状態で Kubernetes 側に `runAsNonRoot: true` を付けると kubelet が UID を解決できず、

```
container has runAsNonRoot and image has non-numeric user (misskey), cannot verify user is non-root
```

で pod が起動しない。

## 変更

```diff
-USER misskey
+USER ${UID}
```

同 stage の `ARG UID="991"`（`useradd -u "${UID}"` で使っているものと同一）を展開し、image config の `User` を数値で焼き込む。

あわせて `package.json` の version を `2026.7.0-na2na-v2` へ上げ、`cd-for-misskey-na2na` でこの変更を含む image が publish されるようにする。

## 挙動への影響

**実行時 UID は 991 のまま変わらない。** 変わるのは image config の `User` フィールドの表現のみ。

`USER` より後の `COPY --chown=misskey:misskey` は COPY 自体が root で実行され、chown は image 内の `/etc/passwd` で名前解決されるため影響を受けない。

## 検証

同じ ARG/USER パターンの最小 Dockerfile をビルドし、image config と実行時 UID を確認した。

```
User = "991"
uid=991(misskey) gid=991(misskey)
```

数値で焼かれ、かつ実行時 UID が変わらないことを確認済み。

## 補足

この Dockerfile は既に全ファイルの setuid/setgid ビットを落としているため (`chmod u-s` / `g-s`)、chart 側で併せて入れる `allowPrivilegeEscalation: false` で壊れる setuid バイナリは存在しない。
